### PR TITLE
UI change; shift+click on a data point now holds the tooltip in place…

### DIFF
--- a/example/template.html
+++ b/example/template.html
@@ -13,6 +13,7 @@
     <h4>Quick Guide</h4>
     <ul>
       <li>Click a point to select it</li>
+      <li>Hold shift and click a point to select it and leave the tooltip active</li>
       <li>Click and drag to select all points within the box</li>
       <li>Hold alt, then drag to select all points within the box, but remove any that were previously selected</li>
       <li>Hold shift, then drag to zoom in on that area</li>


### PR DESCRIPTION
… until it's moused-over again. Useful for selecting and going out-of-window while keeping the tooltip active. Pushed to non-active branch on accident.